### PR TITLE
ActiveMQ Artemisの非推奨のAPIから移行

### DIFF
--- a/src/main/java/com/nablarch/example/sample/mom/EmbeddedMessagingProvider.java
+++ b/src/main/java/com/nablarch/example/sample/mom/EmbeddedMessagingProvider.java
@@ -60,7 +60,7 @@ public class EmbeddedMessagingProvider extends JmsMessagingProvider implements I
         List<QueueConfiguration> queueConfigs = queueList.stream()
                 .map(ActiveMQQueue::getQueueName)
                 .map(name -> {
-                    QueueConfiguration queueConfig = new QueueConfiguration(name);
+                    QueueConfiguration queueConfig = QueueConfiguration.of(name);
                     queueConfig.setRoutingType(RoutingType.ANYCAST);
                     return queueConfig;
                 })


### PR DESCRIPTION
ActiveMQ Artemisで非推奨になったAPIを移行しました。

修正後、Example 4種とテストコードが動作することを確認済みです。